### PR TITLE
chore: Enable detect secrets hook & allow commit hook SHAs to pass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c # v4.6.0
+    rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c  # pragma: allowlist secret - v4.6.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -14,16 +14,22 @@ repos:
     -   id: check-merge-conflict
 
   - repo: https://github.com/PyCQA/flake8
-    rev: cf1542cefa3e766670b2066dd75c4571d682a649 # v7.1.1
+    rev: cf1542cefa3e766670b2066dd75c4571d682a649 # pragma: allowlist secret - v7.1.1
     hooks:
     -   id: flake8
         name: flake8 - Python linting
         args: [--max-line-length=75]
 
   - repo: https://github.com/psf/black
-    rev: b965c2a5026f8ba399283ba3e01898b012853c79 # v24.8.0
+    rev: b965c2a5026f8ba399283ba3e01898b012853c79 # pragma: allowlist secret - v24.8.0
     hooks:
       - id: black
         args: [--line-length=75]
         name: black - Python linting (auto-fixes)
         language_version: python
+
+  -   repo: https://github.com/Yelp/detect-secrets
+      rev: 01886c8a910c64595c47f186ca1ffc0b77fa5458 # pragma: allowlist secret - v1.5.0
+      hooks:
+      -   id: detect-secrets
+          exclude: .*ipynb # ignore false positive hashes in ipynb JSON


### PR DESCRIPTION
Resolves #5 

Adds inline ignore flags for commit SHAs in the pre-commit yaml.